### PR TITLE
Add $VIMRUNTIME

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function * run (context, heroku) {
     command: `mkdir vim
     curl https://s3.amazonaws.com/heroku-vim/vim-7.3.tar.gz --location --silent | tar xz -C vim
       export PATH=$PATH:/app/vim/bin
+      export VIMRUNTIME=/app/vim/share/vim/vim73
     bash`,
     env: context.flags.env,
     showStatus: false,


### PR DESCRIPTION
By default, the VIMRUNTIME is `/app/vimbin/share/vim` on Heroku
This fixes #1
